### PR TITLE
Use fused types and magic dtype from memoryview to simplify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ cyvlfeat.egg-info/*
 *.so
 
 # Let's just ignore all cython built files
+cyvlfeat/generic/generic.c
 cyvlfeat/hog/cyhog.c
+cyvlfeat/kmeans/cykmeans.c
 cyvlfeat/sift/cysift.c
 cyvlfeat/fisher/cyfisher.c
 *.iml

--- a/cyvlfeat/cy_utils.pxd
+++ b/cyvlfeat/cy_utils.pxd
@@ -1,0 +1,5 @@
+cimport numpy as np
+cimport cython
+
+cdef inline np.dtype dtype_from_memoryview(cython.view.memoryview arr):
+    return np.dtype(arr.view.format)

--- a/cyvlfeat/fisher/cyfisher.pyx
+++ b/cyvlfeat/fisher/cyfisher.pyx
@@ -5,13 +5,13 @@
 # This file is modified from part of the VLFeat library and is made available
 # under the terms of the BSD license.
 import numpy as np
-import ctypes
 cimport numpy as np
 cimport cython
 
 # Import the header files
+from cyvlfeat.cy_utils cimport dtype_from_memoryview
 from cyvlfeat._vl.host cimport VL_TYPE_FLOAT, VL_TYPE_DOUBLE
-from cyvlfeat._vl.host cimport vl_size, vl_type
+from cyvlfeat._vl.host cimport vl_size
 from cyvlfeat._vl.fisher cimport vl_fisher_encode
 from cyvlfeat._vl.fisher cimport VL_FISHER_FLAG_NORMALIZED
 from cyvlfeat._vl.fisher cimport VL_FISHER_FLAG_SQUARE_ROOT
@@ -20,44 +20,26 @@ from cyvlfeat._vl.fisher cimport VL_FISHER_FLAG_FAST
 
 
 @cython.boundscheck(False)
-cpdef cy_fisher(np.ndarray X,
-                np.ndarray MEANS,
-                np.ndarray COVARIANCES,
-                np.ndarray PRIORS,
+cpdef cy_fisher(cython.floating[:, ::1] X,
+                cython.floating[:, ::1] means,
+                cython.floating[:, ::1] covariances,
+                cython.floating[::1] priors,
                 bint normalized,
                 bint square_root,
                 bint improved,
                 bint fast,
                 bint verbose):
+    dtype = dtype_from_memoryview(X)
 
     cdef:
-        vl_size n_clusters = MEANS.shape[0]
-        vl_size n_dimensions = MEANS.shape[1]
+        vl_size n_clusters = means.shape[0]
+        vl_size n_dimensions = means.shape[1]
         vl_size n_data = X.shape[0]
-
-        np.ndarray[np.float32_t, ndim=1, mode="c"] encf
-        np.ndarray[np.float32_t, ndim=2, mode="c"] meansf
-        np.ndarray[np.float32_t, ndim=2, mode="c"] covarsf
-        np.ndarray[np.float32_t, ndim=1, mode="c"] priorsf
-        np.ndarray[np.float32_t, ndim=2, mode="c"] Xf
-
-        np.ndarray[np.float64_t, ndim=1, mode="c"] encd
-        np.ndarray[np.float64_t, ndim=2, mode="c"] meansd
-        np.ndarray[np.float64_t, ndim=2, mode="c"] covarsd
-        np.ndarray[np.float64_t, ndim=1, mode="c"] priorsd
-        np.ndarray[np.float64_t, ndim=2, mode="c"] Xd
-
         int flags = 0
-        int num_terms
-
-    if MEANS.dtype != X.dtype:
-        raise TypeError("MEANS does not have the same type as X")
-
-    if COVARIANCES.dtype != X.dtype:
-        raise TypeError("COVARIANCES does not have the same type as X")
-
-    if PRIORS.dtype != X.dtype:
-        raise TypeError("PRIORS does not have the same type as X")
+        int num_terms = 0
+        int vl_float_type = 0
+        cython.floating[::1] enc = np.zeros(2 * n_clusters * n_dimensions,
+                                            dtype=dtype)
 
     if normalized:
         flags |= VL_FISHER_FLAG_NORMALIZED
@@ -82,52 +64,17 @@ cpdef cy_fisher(np.ndarray X,
             n_data, n_clusters, n_dimensions, 2 * n_clusters * n_dimensions,
             square_root, normalized, fast))
 
-    if X.dtype == "float32":
-
-        encf = np.zeros(
-            2 * n_clusters * n_dimensions, dtype=X.dtype
-        )
-        meansf = MEANS
-        covarsf = COVARIANCES
-        priorsf = PRIORS
-        Xf = X
-
-        num_terms = vl_fisher_encode(&encf[0],
-                                     VL_TYPE_FLOAT,
-                                     &meansf[0, 0],
-                                     n_dimensions,
-                                     n_clusters,
-                                     &covarsf[0, 0],
-                                     &priorsf[0],
-                                     &Xf[0, 0],
-                                     n_data,
-                                     flags)
-        enc = encf
-
-    elif X.dtype == "float64":
-
-        encd = np.zeros(
-            2 * n_clusters * n_dimensions, dtype=X.dtype
-        )
-        meansd = MEANS
-        covarsd = COVARIANCES
-        priorsd = PRIORS
-        Xd = X
-
-        num_terms = vl_fisher_encode(&encd[0],
-                                     VL_TYPE_DOUBLE,
-                                     &meansd[0, 0],
-                                     n_dimensions,
-                                     n_clusters,
-                                     &covarsd[0, 0],
-                                     &priorsd[0],
-                                     &Xd[0, 0],
-                                     n_data,
-                                     flags)
-        enc = encd
-    else:
-        raise ValueError("The type of the input data X is not 'float32' nor "
-                         "'float64'.")
+    vl_float_type = VL_TYPE_FLOAT if dtype == np.float32 else VL_TYPE_DOUBLE
+    num_terms = vl_fisher_encode(&enc[0],
+                                 vl_float_type,
+                                 &means[0, 0],
+                                 n_dimensions,
+                                 n_clusters,
+                                 &covariances[0, 0],
+                                 &priors[0],
+                                 &X[0, 0],
+                                 n_data,
+                                 flags)
 
     if verbose:
         print('vl_fisher: sparsity of assignments: {:.2f}% '
@@ -135,4 +82,4 @@ cpdef cy_fisher(np.ndarray X,
             100.0 * (1.0 - <float>num_terms / (n_data * n_clusters + 1e-12)),
             num_terms))
 
-    return enc
+    return np.asarray(enc)


### PR DESCRIPTION
The dtype checks are not required because Cython already enforces
matching types if the same fused type is passed.
